### PR TITLE
Ensure proper write permissions in both the labeled namespace and argo namespace by leveraging shared secret

### DIFF
--- a/playbooks/remove_label.yaml
+++ b/playbooks/remove_label.yaml
@@ -3,15 +3,33 @@
   tasks:
   - name: Print message
     debug:
-      msg: "ArgoCDManaged deleted from namespace {{ ansible_operator_meta.namespace }}. Removing label from namespace."
+      msg: "ArgoCDManaged deleted from namespace {{ ansible_operator_meta.namespace }}."
+
+  - name: 'Read Namespace "{{ ansible_operator_meta.name }}" for expected label'
+    kubernetes.core.k8s_info:
+      api_version: v1
+      kind: Namespace
+      # name: "{{ ansible_operator_meta.name }}"
+      label_selectors:
+        - "argocd.argoproj.io/managed-by={{ ansible_operator_meta.namespace }}"
+      field_selectors:
+        - "metadata.name={{ ansible_operator_meta.name }}"
+    register: labeled_namespace
+
+  - set_fact:
+      namespace_contains_label: "{{ labeled_namespace.resources | length == 1 }}"
+
+  - debug:
+      var: namespace_contains_label
 
   # '/' in a key needs to be replaced with '~1'
   - name: Remove Label from namespace
     kubernetes.core.k8s_json_patch:
       api_version: v1
       kind: Namespace
-      name: "{{ ansible_operator_meta.namespace }}"
+      name: "{{ ansible_operator_meta.name }}"
       patch:
         - op: remove
           path: /metadata/labels/argocd.argoproj.io~1managed-by
     ignore_errors: true
+    when: namespace_contains_label

--- a/roles/argocdmanaged/tasks/main.yml
+++ b/roles/argocdmanaged/tasks/main.yml
@@ -2,7 +2,40 @@
 # tasks file for ArgoCDManaged
 - name: Print message
   debug:
-    msg: "Received request to add namespace {{ ansible_operator_meta.namespace  }} to ArgoCD namespace: {{ argocd_namespace }}"
+    msg: "Received request to add remote namespace {{ ansible_operator_meta.name }} to ArgoCD namespace: {{ ansible_operator_meta.namespace }}"
+
+- name: 'Retrieve secret value from ArgoCD namespace "{{ ansible_operator_meta.namespace }}"'
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: argocd-managed-ns
+    namespace: "{{ ansible_operator_meta.namespace }}"
+  register: secret_result
+
+- set_fact:
+    shared_secret_hash: "{{ secret_result.resources[0].data.shared_secret | default('', true) | hash('sha256') }}"
+    cacheable: no
+    no_log: true
+
+- name: 'Retrieve secret value from remote namespace "{{ ansible_operator_meta.name }}"'
+  kubernetes.core.k8s_info:
+    api_version: v1
+    kind: Secret
+    name: argocd-managed-ns
+    namespace: "{{ ansible_operator_meta.name }}"
+  register: remote_secret_result
+
+- set_fact:
+    # If the secret doesn't exist, or the key doesn't exist, we default to an empty value
+    remote_secret_hash: "{{ remote_secret_result.resources[0].data.shared_secret | default('remote_secret_unset_or_not_found', false) | hash('sha256') }}"
+    cacheable: no
+    no_log: true
+
+- set_fact:
+    shared_secret_hashes_match: "{{ shared_secret_hash == remote_secret_hash }}"
+
+- debug:
+    var: shared_secret_hashes_match
 
 - name: Update Namespace with argocd label
   kubernetes.core.k8s:
@@ -11,6 +44,7 @@
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: "{{ ansible_operator_meta.namespace }}"
+        name: "{{ ansible_operator_meta.name }}"
         labels:
-          argocd.argoproj.io/managed-by: "{{ argocd_namespace }}"
+          argocd.argoproj.io/managed-by: "{{ ansible_operator_meta.namespace }}"
+  when: shared_secret_hashes_match


### PR DESCRIPTION
Fixes #1 

This PR restructures the way this controller works in a way that should prevent inadvertent binding of a namespace to an Argo installation for which the managed-namespace-owner is not authorized.

The design has changed; I'll let maintainers decide how they would like to handle the CRD in this case.

## Change Summary

- A user who has an ArgoCD cluster creates a shared secret with a known name
    - Kubernetes Secret: [argocd-managed-ns](https://github.com/komish/argocd-namespace-operator/commit/8765381dac9df136338ad25de60c2c80a09f69fc#diff-9d638363cbadd5151c61918d05c9059decd2eee53bf218b92c2a6100fa0e8d23R11) with expected key: [shared_secret](https://github.com/komish/argocd-namespace-operator/commit/8765381dac9df136338ad25de60c2c80a09f69fc#diff-9d638363cbadd5151c61918d05c9059decd2eee53bf218b92c2a6100fa0e8d23R16)

- To enroll another namespace to be managed by that installation, they create the same shared secret in the to-be-enrolled namespace as the ArgoCD installation

- If those match, the controller applies the label.

This forces the user binding a namespace to an installation (by way of label) to have write privileges to secrets in both the ArgoCD installation namespace and the enrolled namespace.

## Details

I changed the design a slight bit. In this modified implementation, the user should create their ArgoCDManaged resource in the ArgoCD namespace. The spec value isn't relevant anymore. Instead, the `.metadata.name` of the ArgoCDManaged resource should align with the namespace to be labeled.

The operator will use the namespace containing the ArgoCDManaged resource as the "managing" namespace (i.e. the ArgoCD namespace). So if I wanted to label 10 different namespaces to be managed by one installation, I'd create 10 different ArgoCDManaged resources with the `.metadata.name` value being the same as each of those namespaces.

Here's what an example would look like:

```yaml
apiVersion: pfe.opentlc.com/v1
kind: ArgoCDManaged
metadata:
  name: developer-project-to-be-labeled
  namespace: ns-where-argocd-is
spec: {}                              # this field is no longer relevant
```

This has a nice side-effect of allowing you to `oc get --all argocdmanaged` and get an idea of what namespace is enrolled where.

Some design notes:

- The fixed secret name intends to help avoid conflicts. Assuming a single namespace can be enrolled in a single installation, having fixed values helps a developer that wants to accomplish this know that they're potentially stomping on an existing enrollment.

- The delete logic that cleaned up the finalizer had to be updated to prevent a delete operation in another resource from deleting a label for another enrollment.

- This doesn't quite watch secrets or any other resources as it stands today, which means that a user deleting a secret resource for enrollment could potentially leave a label hanging. It may be worth having a periodic reconciliation that monitors the state of things, but I've left those kinds of logistics as an exercise for whoever.

